### PR TITLE
19 media actions out of menu

### DIFF
--- a/Ghost.Web.React/src/components/FavouriteIconButton.jsx
+++ b/Ghost.Web.React/src/components/FavouriteIconButton.jsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react'
+import { IconButton, Tooltip } from '@mui/material'
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import PropTypes from 'prop-types'
+
+export const FavouriteIconButton = ({ state, update, id, toggleFn }) => {
+  const [loading, setLoading] = useState(false);
+
+  const handleToggleFavourite = async () => {
+    if (loading) return;
+    setLoading(true);
+    try {
+      const favourite = await toggleFn(id)
+      update(favourite);
+    } finally {
+      setLoading(false);
+    }
+  }
+  return <Tooltip title={state ? "Unfavourite" : "Favourite"}>
+    <IconButton aria-label="add to favourites" onClick={handleToggleFavourite} disabled={loading}>
+      {state ? <FavoriteIcon /> : <FavoriteBorderIcon />}
+    </IconButton>
+  </Tooltip>
+}
+
+FavouriteIconButton.propTypes = {
+  state: PropTypes.bool.isRequired,
+  update: PropTypes.func,
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  toggleFn: PropTypes.func
+}

--- a/Ghost.Web.React/src/components/Media.jsx
+++ b/Ghost.Web.React/src/components/Media.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useAsync } from 'react-async-hook'
 import axios from 'axios'
-import { Container, Grid, IconButton, Paper, Skeleton } from '@mui/material'
+import { Container, Grid, IconButton, Paper, Skeleton, Box, Tooltip } from '@mui/material'
 import { mergeDeepRight } from 'ramda'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 
@@ -11,10 +11,11 @@ import { VideoGenres } from './VideoGenres.jsx'
 import { VideoActors } from './VideoActors.jsx'
 import { TextEdit } from './TextEdit.jsx'
 import { VideoMetaData } from './VideoMetaData.jsx'
-import { VideoMenu } from './VideoMenu.jsx'
+import { items, VideoMenu } from './VideoMenu.jsx'
 import { ChipSkeleton } from './ChipSkeleton.jsx'
 import { Chapters } from './Chapters.jsx'
-import { generateVideoUrl } from '../services/video.service';
+import { generateVideoUrl, toggleFavourite } from '../services/video.service';
+import { FavouriteIconButton } from './FavouriteIconButton.jsx'
 
 const fetchMedia = async (id) => (await axios.get(`/media/${id}/info`)).data
 const fetchGenres = async (id) => (await axios.get(`/genre/video/${id}`)).data
@@ -46,6 +47,8 @@ export const Media = () => {
     updateProgress(params.id, progress)
   }
 
+  const updateMedia = (val) => media.set(mergeDeepRight(media, { result: val }));
+
   return <>
     {media.loading && <Skeleton height="200px" width="100%" />}
     {!media.loading &&
@@ -55,20 +58,15 @@ export const Media = () => {
         type={media.result.type}
         poster={media.result.thumbnail ? `${axios.defaults.baseURL}/image/${media.result.thumbnail.id}/${media.result.thumbnail.name}` : undefined}
         duration={media.result.runtime}
-        currentProgress={media.result.progress}
+        currentProgress={media.result.progress || 0}
         progressUpdate={handleProgressUpdate}
       />}
     <Container sx={{ paddingX: 0 }}>
       <Paper sx={{ p: 2 }}>
-        <Grid container spacing={1}>
-          <Grid item xs={10} sm={11}>
-            {media.loading && <Skeleton height="50px" width="100%" />}
-            {!media.loading && <TextEdit text={media.result.title} update={async (title) => {
-              const video = await updateTitle(params.id, title)
-              media.set(mergeDeepRight(media, { result: { title: video.title } }))
-            }} />}
-          </Grid>
-          <Grid item xs={2} sm={1}><IconButton
+        {!media.loading && <Box sx={{ display: 'flex', flexDirection: 'row' }}>
+          <FavouriteIconButton id={params.id} state={media.result.favourite} toggleFn={toggleFavourite} update={favourite => updateMedia({ favourite })} />
+          < IconButton
+            sx={{ marginLeft: 'auto' }}
             onClick={handleMenuClick}
             id={`${params.id}-video-card-menu-button`}
             aria-controls={!!menuAnchorEl ? 'video-card-menu' : undefined}
@@ -77,8 +75,12 @@ export const Media = () => {
           >
             <MoreVertIcon />
           </IconButton>
-          </Grid>
-        </Grid>
+        </Box>}
+        {media.loading && <Skeleton height="50px" width="100%" />}
+        {!media.loading && <TextEdit text={media.result.title} update={async (title) => {
+          const video = await updateTitle(params.id, title)
+          media.set(mergeDeepRight(media, { result: { title: video.title } }))
+        }} />}
         {genresPage.loading && <ChipSkeleton />}
         {!genresPage.loading && <VideoGenres genres={genresPage.result} videoId={params.id}
           updateGenres={async (genres) => {
@@ -112,16 +114,19 @@ export const Media = () => {
       </Paper>
     </Container>
 
-    {!media.loading && <VideoMenu
-      source={videoSource}
-      anchorEl={menuAnchorEl}
-      handleClose={handleMenuClose}
-      videoId={+params.id}
-      title={media.result.title}
-      removeVideo={() => navigate(-1)}
-      setVideo={(video) => media.set(mergeDeepRight(media, { result: video }))}
-      favourite={!!media.result.favourite}
-      progress={progress}
-    />}
+    {
+      !media.loading && <VideoMenu
+        source={videoSource}
+        anchorEl={menuAnchorEl}
+        handleClose={handleMenuClose}
+        videoId={+params.id}
+        title={media.result.title}
+        removeVideo={() => navigate(-1)}
+        setVideo={(video) => media.set(mergeDeepRight(media, { result: video }))}
+        favourite={!!media.result.favourite}
+        progress={progress}
+        hideItems={[items.favourite]}
+      />
+    }
   </>
 }

--- a/Ghost.Web.React/src/components/Media.jsx
+++ b/Ghost.Web.React/src/components/Media.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useAsync } from 'react-async-hook'
 import axios from 'axios'
-import { Container, Grid, IconButton, Paper, Skeleton, Box, Tooltip } from '@mui/material'
+import { Container, Grid, IconButton, Paper, Skeleton, Box } from '@mui/material'
 import { mergeDeepRight } from 'ramda'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 
@@ -58,7 +58,7 @@ export const Media = () => {
         type={media.result.type}
         poster={media.result.thumbnail ? `${axios.defaults.baseURL}/image/${media.result.thumbnail.id}/${media.result.thumbnail.name}` : undefined}
         duration={media.result.runtime}
-        currentProgress={media.result.progress || 0}
+        currentProgress={media.result.progress}
         progressUpdate={handleProgressUpdate}
       />}
     <Container sx={{ paddingX: 0 }}>

--- a/Ghost.Web.React/src/components/VideoCard.jsx
+++ b/Ghost.Web.React/src/components/VideoCard.jsx
@@ -7,14 +7,12 @@ import MoreVertIcon from '@mui/icons-material/MoreVert'
 import { items, VideoMenu } from './VideoMenu.jsx'
 import { generateVideoUrl, toggleFavourite } from '../services/video.service.js'
 import { mergeDeepLeft } from 'ramda'
-import FavoriteIcon from '@mui/icons-material/Favorite';
-import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import { VideoProgress } from './VideoProgress.jsx'
+import { FavouriteIconButton } from './FavouriteIconButton.jsx'
 
 export const VideoCard = ({ video, remove }) => {
   const [localVideo, setLocalVideo] = useState(video);
   const [anchorEl, setAnchorEl] = useState(null);
-  const [loadingFavourite, setLoadingFavourite] = useState(false);
 
   const handleMenuClick = (event) => {
     setAnchorEl(event.currentTarget)
@@ -22,17 +20,6 @@ export const VideoCard = ({ video, remove }) => {
 
   const handleMenuClose = () => {
     setAnchorEl(null)
-  }
-
-  const handleFavourite = async () => {
-    if (loadingFavourite) return;
-    setLoadingFavourite(true);
-    try {
-      const favourite = await toggleFavourite(localVideo.id)
-      setLocalVideo(mergeDeepLeft({ favourite }));
-    } finally {
-      setLoadingFavourite(false);
-    }
   }
 
   const actors = localVideo.actors.length > 0 ? localVideo.actors.map(a => <Chip
@@ -74,9 +61,11 @@ export const VideoCard = ({ video, remove }) => {
       <VideoProgress duration={localVideo.runtime} current={localVideo.progress} />
     </CardActionArea>
     <CardActions disableSpacing>
-      <IconButton aria-label="add to favourites" onClick={handleFavourite} disabled={loadingFavourite}>
-        {localVideo.favourite ? <FavoriteIcon /> : <FavoriteBorderIcon />}
-      </IconButton>
+      <FavouriteIconButton
+        id={localVideo.id}
+        state={localVideo.favourite}
+        toggleFn={toggleFavourite}
+        update={favourite => setLocalVideo(mergeDeepLeft({ favourite }))} />
       <IconButton
         sx={{ marginLeft: "auto" }}
         onClick={handleMenuClick}


### PR DESCRIPTION
Moved favourite button to the media home page.
Gives title more space and makes accessing the favourite button easier