### PR TITLE
52, 53 - save search & filtering to session storage

### DIFF
--- a/Ghost.Web.React/src/components/GenreFilter.jsx
+++ b/Ghost.Web.React/src/components/GenreFilter.jsx
@@ -5,7 +5,7 @@ import { prop } from 'ramda'
 import usePromise from '../services/use-promise'
 import { fetchGenres } from '../services/genre.service'
 
-export const GenreFilter = ({ setSelectedGenres }) => {
+export const GenreFilter = ({ setSelectedGenres, selectedGenres }) => {
   const [allGenres, , loadingAllGenres] = usePromise(() => fetchGenres())
   const autocompleteRef = useRef()
 
@@ -17,10 +17,11 @@ export const GenreFilter = ({ setSelectedGenres }) => {
       onChange={(e, newGenres) => setSelectedGenres(newGenres)}
       options={allGenres?.map(prop('name')) || []}
       loading={loadingAllGenres}
+      defaultValue={selectedGenres}
       renderInput={(params) => (
         <TextField
           size="small"
-          sx={{ mr: 6 }}
+          sx={{ minWidth: '100px' }}
           placeholder="Genres"
           id="genre-filter-text-box"
           inputRef={autocompleteRef}

--- a/Ghost.Web.React/src/components/VideoView.jsx
+++ b/Ghost.Web.React/src/components/VideoView.jsx
@@ -4,6 +4,7 @@ import { Box, Grid, Pagination } from '@mui/material'
 import { remove } from 'ramda'
 
 import usePromise from '../services/use-promise'
+import useLocalState from '../services/use-local-state'
 
 import watchStates from '../constants/watch-states'
 
@@ -21,14 +22,23 @@ const removeVideo =
     setVideos(remove(index, 1))
 
 export const VideoView = ({ fetchFn }) => {
-  const [page, setPage] = useState(1)
-  const [limit] = useState(48)
-  const [search, setSearch] = useState('')
+  const [page, setPage] = useLocalState('page', 1)
+  const [limit] = useLocalState('limit', 48)
+  const [search, setSearch] = useLocalState('search', '')
   const [total, setTotal] = useState(0)
-  const [sortBy, setSortBy] = useState('date-added')
-  const [sortAscending, setSortAscending] = useState(false)
-  const [watchState, setWatchState] = useState(watchStates.unwatched)
-  const [selectedGenres, setSelectedGenres] = useState([])
+  const [sortBy, setSortBy] = useLocalState('sortBy', 'date-added')
+  const [sortAscending, setSortAscending] = useLocalState(
+    'sortAscending',
+    false,
+  )
+  const [watchState, setWatchState] = useLocalState(
+    'watchState',
+    watchStates.unwatched,
+  )
+  const [selectedGenres, setSelectedGenres] = useLocalState(
+    'selectedGenres',
+    [],
+  )
   const [count, setCount] = useState(0)
   const [videos, setVideos] = useState([])
   const [videosPage, error, loading] = usePromise(

--- a/Ghost.Web.React/src/components/WatchState.jsx
+++ b/Ghost.Web.React/src/components/WatchState.jsx
@@ -14,26 +14,26 @@ export const WatchState = ({ watchState, setWatchState }) => {
         value={watchState}
         label={'Watch state'}
         onChange={(e) => setWatchState(e.target.value)}
+        defaultValue={watchState.value}
       >
-        <MenuItem value={watchStates.inProgress}>
+        <MenuItem value={watchStates.inProgress.value}>
           {watchStates.inProgress.name}
         </MenuItem>
-        <MenuItem value={watchStates.watched}>
+        <MenuItem value={watchStates.watched.value}>
           {watchStates.watched.name}
         </MenuItem>
-        <MenuItem value={watchStates.unwatched}>
+        <MenuItem value={watchStates.unwatched.value}>
           {watchStates.unwatched.name}
         </MenuItem>
-        <MenuItem value={watchStates.all}>{watchStates.all.name}</MenuItem>
+        <MenuItem value={watchStates.all.value}>
+          {watchStates.all.name}
+        </MenuItem>
       </Select>
     </FormControl>
   )
 }
 
 WatchState.propTypes = {
-  watchState: PropTypes.shape({
-    value: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired,
-  }).isRequired,
+  watchState: PropTypes.string.isRequired,
   setWatchState: PropTypes.func.isRequired,
 }

--- a/Ghost.Web.React/src/services/use-local-state.js
+++ b/Ghost.Web.React/src/services/use-local-state.js
@@ -1,0 +1,23 @@
+import { useState } from 'react'
+
+export default function useLocalState(key, initialState) {
+  let localValue = sessionStorage.getItem(key)
+  if (localValue === undefined || localValue === null) {
+    localValue = initialState
+  } else {
+    try {
+      localValue = JSON.parse(localValue)
+    } catch (err) {
+      localValue = initialState
+    }
+  }
+
+  const [value, setValue] = useState(localValue)
+
+  const setLocalValue = (newValue) => {
+    sessionStorage.setItem(key, JSON.stringify(newValue))
+    setValue(newValue)
+  }
+
+  return [value, setLocalValue]
+}

--- a/Ghost.Web.React/src/services/use-promise.js
+++ b/Ghost.Web.React/src/services/use-promise.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react"
+import { useEffect, useState } from 'react'
 
 export default function usePromise(f, deps) {
   const [result, setResult] = useState()
@@ -10,13 +10,13 @@ export default function usePromise(f, deps) {
     setLoading(true)
 
     f()
-      .then(r => {
+      .then((r) => {
         if (subscribed) {
           setLoading(false)
           setResult(r)
         }
       })
-      .catch(e => {
+      .catch((e) => {
         if (subscribed) {
           setLoading(false)
           setError(e)

--- a/Ghost.Web.React/src/services/video.service.js
+++ b/Ghost.Web.React/src/services/video.service.js
@@ -50,7 +50,7 @@ export const constructVideoParams = ({
     params.push(`ascending=${ascending}`)
   }
   if (watchState !== undefined && watchState !== null) {
-    params.push(`watchState=${watchState.value}`)
+    params.push(`watchState=${watchState}`)
   }
   if (genres !== undefined && genres !== null && genres.length > 0) {
     params.push(


### PR DESCRIPTION
Instead of adding the filtering into a context api or hoisting it up it seemed to be easier to just create a custom hook to pull from session storage.
This then closes 2 tickets