### PR TITLE
106 prevent multiple scans from happening at the same time

### DIFF
--- a/Ghost.Web.React/src/components/LibraryCard.jsx
+++ b/Ghost.Web.React/src/components/LibraryCard.jsx
@@ -22,7 +22,6 @@ import axios from 'axios'
 
 export const LibraryCard = ({ library, updateLibraries }) => {
   const [anchorEl, setAnchorEl] = useState(null)
-  const [loadingFullSync, setLoadingFullSync] = useState(false)
   const [loadingSync, setLoadingSync] = useState(false)
   const [loadingDelete, setLoadingDelete] = useState(false)
   const [loadingSyncNfo, setLoadingSyncNfo] = useState(false)
@@ -95,12 +94,12 @@ export const LibraryCard = ({ library, updateLibraries }) => {
   }
 
   const fullSync = async () => {
-    setLoadingFullSync(true);
+    setLoadingSync(true);
     try {
       await axios.put(`/library/${library.id}/sync`)
       await axios.put(`/library/${library.id}/generate-thumbnails`)
     } finally {
-      setLoadingFullSync(false)
+      setLoadingSync(false)
       handleMenuClose()
     }
   }
@@ -138,10 +137,10 @@ export const LibraryCard = ({ library, updateLibraries }) => {
       >
         <MenuItem onClick={fullSync}>
           <ListItemIcon>
-            {loadingFullSync && (
+            {loadingSync && (
               <CircularProgress sx={{ mr: 1 }} fontSize="small" />
             )}
-            {!loadingFullSync && <SyncIcon fontSize="small" />}
+            {!loadingSync && <SyncIcon fontSize="small" />}
           </ListItemIcon>
           <ListItemText>Full Sync</ListItemText>
         </MenuItem>

--- a/Ghost.Web.React/src/components/Video.jsx
+++ b/Ghost.Web.React/src/components/Video.jsx
@@ -33,26 +33,26 @@ export const Video = ({
   const [keysDown, setKeysDown] = useState({});
 
   useEffect(() => {
-    videoRef.current?.load()
-    videoRef.current?.focus()
-    if (videoRef) {
+    videoRef?.current?.load()
+    videoRef?.current?.focus()
+    if (videoRef && videoRef.current) {
       videoRef.current.ontimeupdate = () => {
-        setCurrentTime(videoRef.current.currentTime)
+        setCurrentTime(videoRef?.current?.currentTime) // <-- this was the problem not any of the others (that I know of)
       }
     }
   }, [source])
 
   useEffect(() => {
-    if (currentProgress !== undefined) {
+    if (videoRef && videoRef.current && currentProgress !== undefined) {
       videoRef.current.currentTime = currentProgress
       setCurrentTime(currentProgress)
     }
   }, [currentProgress])
 
   useEffect(() => {
-    if (chapter) {
+    if (chapter && videoRef && videoRef.current) {
       videoRef.current.currentTime = chapter.timestamp / 1000
-      videoRef.current.play()
+      videoRef?.current.play()
     }
   }, [chapter])
 
@@ -113,7 +113,7 @@ export const Video = ({
         playsInline={false}
         src={source}
         type={type}
-        onPlay={() => videoRef.current.focus()}
+        onPlay={() => videoRef?.current.focus()}
       ></video>
       <VideoProgress duration={duration} current={currentTime} />
     </Box>


### PR DESCRIPTION
Prevent multiple sync jobs from being allowed to run at the same time from the frontend.
The simple fix was just to have the front end have both sync jobs running on one loading variable.