### PR TITLE
remove current progress from the video for now

### DIFF
--- a/Ghost.Web/src/components/Video.jsx
+++ b/Ghost.Web/src/components/Video.jsx
@@ -21,7 +21,6 @@ export const Video = ({
   poster,
   chapter,
   duration,
-  currentProgress,
   progressUpdate,
   videoRef,
   loseFocus,
@@ -37,17 +36,10 @@ export const Video = ({
     videoRef?.current?.focus()
     if (videoRef && videoRef.current) {
       videoRef.current.ontimeupdate = () => {
-        setCurrentTime(videoRef?.current?.currentTime) // <-- this was the problem not any of the others (that I know of)
+        setCurrentTime(videoRef?.current?.currentTime)
       }
     }
   }, [source, videoRef])
-
-  useEffect(() => {
-    if (videoRef && videoRef.current && currentProgress !== undefined) {
-      videoRef.current.currentTime = currentProgress
-      setCurrentTime(currentProgress)
-    }
-  }, [currentProgress, videoRef])
 
   useEffect(() => {
     if (chapter && videoRef && videoRef.current) {
@@ -133,7 +125,6 @@ Video.propTypes = {
   }),
   duration: PropTypes.number.isRequired,
   progressUpdate: PropTypes.func.isRequired,
-  currentProgress: PropTypes.number,
   videoRef: PropTypes.object.isRequired,
   loseFocus: PropTypes.func,
   setStartMark: PropTypes.func,

--- a/Ghost.Web/src/pages/Media.jsx
+++ b/Ghost.Web/src/pages/Media.jsx
@@ -158,7 +158,6 @@ export const Media = () => {
               : undefined
           }
           duration={media.runtime}
-          currentProgress={media?.progress}
           progressUpdate={handleProgressUpdate}
           videoRef={videoRef}
           loseFocus={refocusFn}
@@ -321,9 +320,9 @@ export const Media = () => {
           favourite={!!media.favourite}
           progress={progress}
           hideItems={[
-            videoMenuItems.favourite, 
-            videoMenuItems.resetProgress, 
-            videoMenuItems.toggleSelected, 
+            videoMenuItems.favourite,
+            videoMenuItems.resetProgress,
+            videoMenuItems.toggleSelected,
             videoMenuItems.removeFromPlaylist]}
           editing={editMode}
           setEditing={setEditMode}


### PR DESCRIPTION
Temporarily removed the current progress when going to a video
The drawback is that it will always start at 0:00 now and not from where you left off on the video.
This is due to iOS not liking when this is set for some reason.